### PR TITLE
refactor: Move userID domain regex to `sdk-helpers.ts`

### DIFF
--- a/src/migrator.ts
+++ b/src/migrator.ts
@@ -1,7 +1,7 @@
 import * as sdk from "matrix-js-sdk";
 
 import { DirectMessages, IgnoredUserList, MigratableRoom, ProfileInfo } from "./collector";
-import { JoinRule, catchNotFound, patiently } from "./sdk-helpers";
+import { MXID_REGEX, JoinRule, catchNotFound, patiently } from "./sdk-helpers";
 import { sleep } from "matrix-js-sdk/lib/utils";
 
 import EventEmitter from "events"
@@ -124,7 +124,7 @@ async function migrateProfile(profileInfo: ProfileInfo, target: sdk.MatrixClient
         await target.setDisplayName(profileInfo.displayname);
     }
     if (profileInfo.avatar_url) {
-        const [, targetServerName] = target.getUserId()!.match(/^@[^:]+:(.+)$/)!;
+        const targetServerName = target.getUserId()!.match(MXID_REGEX)![2];
         const [, sourceAvatarServerName] = profileInfo.avatar_url.match(/^mxc:\/\/([^/]+)/)!
         if (sourceAvatarServerName != targetServerName) {
             const httpUrl = target.mxcUrlToHttp(profileInfo.avatar_url)!;

--- a/src/sdk-helpers.ts
+++ b/src/sdk-helpers.ts
@@ -11,6 +11,8 @@ export enum JoinRule {
     KnockRestricted = 'knock_restricted',
 }
 
+export const MXID_REGEX = /([^:]*):(.*)/;
+
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace JoinRule {
     export function fromContent(content: sdk.IContent): JoinRule {

--- a/src/web/LoginForm.tsx
+++ b/src/web/LoginForm.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import * as sdk from "matrix-js-sdk";
+import { MXID_REGEX } from "../sdk-helpers";
 import ImageMaybe from './ImageMaybe';
 
 interface SsoProvider {
@@ -68,7 +69,7 @@ export default class LoginForm extends React.Component<Props, State> {
     }
 
     async getBaseUrl(userId: string) {
-        const [, domain] = userId.match('[^:]+:(.*)')!;
+        const domain = userId.match(MXID_REGEX)![2];
         const wellKnown = await sdk.AutoDiscovery.getRawClientConfig(domain);
         return wellKnown['m.homeserver']?.base_url ?? 'https://' + domain;;
     }


### PR DESCRIPTION
By doing so, we also resolve the bug where the regex wasn't used consistently.